### PR TITLE
admin: show dataset types not authorized but with active dataset registration

### DIFF
--- a/admin/src/main/java/nl/ipo/cds/admin/ba/controller/BronhouderNAW.java
+++ b/admin/src/main/java/nl/ipo/cds/admin/ba/controller/BronhouderNAW.java
@@ -6,9 +6,21 @@ import nl.ipo.cds.domain.Bronhouder;
 public class BronhouderNAW {
 
 	private Bronhouder bronhouder;
+	private boolean hasUnauthorizedThema = false;
 
 	public BronhouderNAW(Bronhouder bronhouder){
 		this.bronhouder = bronhouder;
+	}
+
+	/**
+	 * Make a wrapper class for bronhouder and set a flag when it has unauthorized datasets
+	 * @param bronhouder
+	 * @param hasUnauthorizedThema true if it has one or more datasets that do not belong to authorized themas<br>
+	 * default false 
+	 */
+	public BronhouderNAW(Bronhouder bronhouder, boolean hasUnauthorizedThema){
+		this.bronhouder = bronhouder;
+		this.hasUnauthorizedThema = hasUnauthorizedThema;
 	}
 
 	public Long getId() {
@@ -89,6 +101,14 @@ public class BronhouderNAW {
 
 	public void setBronhouder(Bronhouder bronhouder) {
 		this.bronhouder = bronhouder;
+	}
+
+	public boolean isHasUnauthorizedThema() {
+		return hasUnauthorizedThema;
+	}
+
+	public void setHasUnauthorizedThema(boolean hasUnauthorizedThema) {
+		this.hasUnauthorizedThema = hasUnauthorizedThema;
 	}
 
 }

--- a/admin/src/main/webapp/WEB-INF/views/ba/datasetconfig.vm
+++ b/admin/src/main/webapp/WEB-INF/views/ba/datasetconfig.vm
@@ -50,7 +50,7 @@ require ([
 			location.href=url;
 		</script>
 		#foreach($b in $bronhouders)
-		    <option value="$b.id"#if ($b.id==$bronhouder.id) selected="selected"#end>$b.naam</option>
+		    <option value="$b.id"#if ($b.id==$bronhouder.id) selected="selected"#end>#if($b.hasUnauthorizedThema) !! #end $b.bronhouderNaam</option>
 		#end
 	</select>
 
@@ -58,7 +58,7 @@ require ([
 	<label>Thema:&nbsp;&nbsp;&nbsp;
 	<select data-dojo-type="dijit/form/Select" id="thema" name="thema" required="true"  title="Thema waaronder datasets zijn gegroepeerd">
 		#foreach($thema in $themaList)
-		    <option value="#e($thema.naam)"#if($thema.naam == $currentThema.naam) selected="selected"#end>$thema.naam</option>
+		    <option value="#e($thema.naam)"#if($thema.naam == $currentThema.naam) selected="selected"#end>#if($notAuthorizedThemaList.contains($thema.naam)) !! #end $thema.naam</option>
 		#end
 	</select>
 	</label>

--- a/admin/src/main/webapp/WEB-INF/views/help/bronhouder.vm
+++ b/admin/src/main/webapp/WEB-INF/views/help/bronhouder.vm
@@ -447,6 +447,8 @@
 			</div><br/>
 			<div class="note">NB. De keuzelijst voor bronhouder bovenin is alleen actief als men als beheerder is ingelogd.<br/>
 			Een beheerder kan de dataset gegevens van alle bronhouders inzien en aanpassen.</div>
+			<div class="note">NB. Het kan voorkomen dat er datasets aan een bronhouder zijn toegekend terwijl dit niet bedoeld is.<br/>
+			Een beheerder ziet de betreffende bronhouder en dataset gemarkeerd met '!!' en kan de deze datasets verwijderen.</div>
 		<br/>
 		<br/>
     </div>


### PR DESCRIPTION
Datasets that are linked to a bronhouder but where the bronhouder is not authorized to use them (via 
themabronhouderauthorization), are now marked in the listboxes of tab 'Datasets' when the user is logged in as 'beheerder'.
