### PR TITLE
Fix behavior when removing datasets

### DIFF
--- a/admin/src/main/java/nl/ipo/cds/admin/ba/controller/DatasetController.java
+++ b/admin/src/main/java/nl/ipo/cds/admin/ba/controller/DatasetController.java
@@ -5,9 +5,7 @@ package nl.ipo.cds.admin.ba.controller;
 
 import java.security.Principal;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -218,6 +216,8 @@ public class DatasetController{
 		deleteJob.setDatasetType(dataset.getDatasetType());
 		deleteJob.setUuid(dataset.getUuid());
 		jobCreator.putJob (deleteJob);
+		
+		managerDao.delete (dataset);
 
 		/* Check whether to create a transform Job, by checking if there is already a TRANSFORM job that
 		 * hasn't started yet

--- a/etl-proces/src/main/java/nl/ipo/cds/etl/process/RemoveProcess.java
+++ b/etl-proces/src/main/java/nl/ipo/cds/etl/process/RemoveProcess.java
@@ -10,7 +10,6 @@ import javax.sql.DataSource;
 import nl.idgis.commons.jobexecutor.Job;
 import nl.idgis.commons.jobexecutor.JobLogger;
 import nl.idgis.commons.jobexecutor.Process;
-import nl.ipo.cds.dao.ManagerDao;
 import nl.ipo.cds.domain.Bronhouder;
 import nl.ipo.cds.domain.DatasetType;
 import nl.ipo.cds.domain.RemoveJob;
@@ -44,22 +43,6 @@ public class RemoveProcess implements Process<RemoveJob> {
 		log.debug("uuid: " + uuid);
 
 		Connection connection = DataSourceUtils.getConnection(dataSource);
-		
-		// remove dataset from manager schema
-		try {
-			PreparedStatement removeDataset 
-				= connection.prepareStatement("delete from manager.dataset where bronhouder_id = ? and type_id = ? and uuid=?");
-			removeDataset.setLong(1, bronhouder.getId());
-			removeDataset.setLong(2, datasetType.getId());
-			removeDataset.setString(3, uuid);
-			log.debug("delete from manager.dataset");
-			log.debug("delete sql statement: " + removeDataset);
-			log.debug("# of deleted datasets: " + removeDataset.executeUpdate());
-			removeDataset.close();
-		} catch (SQLException e2) {
-			log.debug("Failed deleting dataset from manager schema" );
-			throw new RuntimeException("Failed to remove dataset from manager schema" , e2);
-		}
 
 		// remove data from bron schema, 
 		// a transform job will then remove data from inspire schema

--- a/etl-proces/src/main/java/nl/ipo/cds/etl/process/TransformProcess.java
+++ b/etl-proces/src/main/java/nl/ipo/cds/etl/process/TransformProcess.java
@@ -1,8 +1,10 @@
 package nl.ipo.cds.etl.process;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import nl.idgis.commons.jobexecutor.Job;
 import nl.idgis.commons.jobexecutor.JobLogger;
@@ -45,13 +47,18 @@ public class TransformProcess implements Process<TransformJob>, ApplicationConte
 	}
 
 	private List<String> getThemeNamesThatNeedTransformation () {
+		final Set<String> themeNames = new LinkedHashSet<String> ();
 		List<Thema> themas = managerDao.getImportedThemasWithoutSubsequentTransform();
-		List<String> themeNames = new ArrayList<String> (themas.size());
 		for (Thema thema : themas) {
-			log.debug("needs transformation: " + thema); 
+			log.debug("needs transformation (imported): " + thema); 
 			themeNames.add(thema.getNaam());
 		}
-		return themeNames;
+		themas = managerDao.getRemovedThemasWithoutSubsequentTransform();
+		for (Thema thema : themas) {			
+			log.debug("needs transformation (removed): " + thema); 
+			themeNames.add(thema.getNaam());
+		}
+		return new ArrayList<String>(themeNames);
 	}
 	
 	@Override

--- a/managerDB/src/main/java/nl/ipo/cds/dao/ManagerDao.java
+++ b/managerDB/src/main/java/nl/ipo/cds/dao/ManagerDao.java
@@ -146,6 +146,13 @@ public interface ManagerDao {
 	 * @return list of themas, for which data needs to be transformed
 	 */	
 	List<Thema> getImportedThemasWithoutSubsequentTransform();
+
+	/**
+	 * Returns all themas for which data has been successfully removed, but not transformed yet.
+	 * 
+	 * @return list of themas, for which data needs to be removed
+	 */		
+	List<Thema> getRemovedThemasWithoutSubsequentTransform();	
 	
 	/**
 	 * Returns the last completed jobs. Results are ordered by 'bronhouder'
@@ -430,4 +437,5 @@ public interface ManagerDao {
 	void create(MetadataDocument metatataDocument);
 	void update(MetadataDocument metatataDocument);
 	void delete(MetadataDocument metatataDocument);
+
 }

--- a/managerDB/src/main/java/nl/ipo/cds/dao/impl/ManagerDaoImpl.java
+++ b/managerDB/src/main/java/nl/ipo/cds/dao/impl/ManagerDaoImpl.java
@@ -449,6 +449,33 @@ public class ManagerDaoImpl implements ManagerDao {
 			return null;
 		}
 	}	
+
+	@Override
+	public List<Thema> getRemovedThemasWithoutSubsequentTransform() {
+		final TypedQuery<Thema> query = entityManager.createQuery (
+				"select distinct thema " +		
+				"from " +
+					"EtlJob job " +
+					"join job.datasettype as dst " +
+					"join dst.thema as thema " +
+				"where " +
+					"job.status = ?1 " +
+					"and type (job) = RemoveJob " +
+					"and not exists(from EtlJob as transform " +
+						"where transform.status = ?1 " +
+						"and type (transform) = TransformJob " +
+						"and transform.startTime >= job.finishTime)",
+				Thema.class
+			);
+		query.setParameter (1, Job.Status.FINISHED);
+		try {
+			return query.getResultList();
+		} catch (EmptyResultDataAccessException e) {
+			return null;
+		} catch (NoResultException e) {
+			return null;
+		}
+	}
 	
 	@Override
 	public EtlJob getLastTransformJob(Job.Status jobStatus) {


### PR DESCRIPTION
Fixes two issues:
- After removing a dataset via the UI, the DatasetConfig view will reflect the change immediately.
- Transformation is scheduled for removed datasets as well, so the inspire schema gets cleaned up.
